### PR TITLE
fix(front): hamburger menu not working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Next Release
 
+### Users
+- **Bug Fixes:**
+  - front: hamburger menu not working
+
 ### Contributors
 - **Documentation:**
   - Translate project backlog from French to English

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,7 +78,7 @@ Ces scripts s'exécutent directement dans le contexte du répertoire `front`.
   ou pour n'exécuter que certains fichiers de tests :
 
   ```bash
-  ./npm run cy -- --spec '**/liste-idees.component.cy.ts'
+  ./npm run ct -- --spec '**/liste-idees.component.cy.ts'
   ```
 
   > *A faire* : les tests de composants sont pour la plupart minimalistes (montage du composant uniquement).

--- a/docs/en/frontend-dev.md
+++ b/docs/en/frontend-dev.md
@@ -320,7 +320,7 @@ describe('BackendService', () => {
 **Run specific component tests**:
 
 ```bash
-./npm run cy -- --spec '**/liste-idees.component.cy.ts'
+./npm run ct -- --spec '**/liste-idees.component.cy.ts'
 ```
 
 **Interactive mode**:

--- a/front/src/app/header/header.component.html
+++ b/front/src/app/header/header.component.html
@@ -1,108 +1,105 @@
 <nav class="navbar navbar-expand-md navbar-dark bg-dark fixed-top">
   <a class="navbar-brand ms-2" href="#">Tirage cadeaux</a>
-  <button
-    class="navbar-toggler"
-    type="button"
-    data-toggle="collapse"
-    data-target="#navbarsExampleDefault"
-    aria-controls="navbarsExampleDefault"
-    aria-expanded="false"
-    aria-label="Toggle navigation"
-  >
-    <span class="navbar-toggler-icon"></span>
-  </button>
 
-  <div
-    *ngIf="utilisateurConnecte$ | async as utilisateur"
-    class="collapse navbar-collapse"
-    id="navbarsExampleDefault"
-  >
-    <ul class="navbar-nav me-auto">
-      <ng-container *ngIf="occasions$ | async as occasions">
-        <li ngbDropdown class="nav-item dropdown" *ngIf="occasions.length > 0">
-          <button
-            class="nav-link"
-            id="menuMesOccasions"
-            [ngClass]="{ active: menuActif === '/occasion' }"
-            ngbDropdownToggle
-          >
-            Mes occasions
-          </button>
-          <div
-            ngbDropdownMenu
-            class="dropdown-menu-dark"
-            aria-labelledby="menuMesOccasions"
-          >
-            <a
-              ngbDropdownItem
-              class="menuMesOccasionsItem"
-              [routerLink]="['/occasion', o.id]"
-              *ngFor="let o of occasions"
-              [ngClass]="{
-                active: menuActif === '/occasion' && idOccasionActive === o.id
-              }"
-              >{{ o.titre }}</a
+  <ng-container *ngIf="utilisateurConnecte$ | async as utilisateur">
+    <button
+      class="navbar-toggler"
+      type="button"
+      (click)="isMenuCollapsed = !isMenuCollapsed"
+      aria-controls="navbarsExampleDefault"
+      [attr.aria-expanded]="!isMenuCollapsed"
+      aria-label="Toggle navigation"
+    >
+      <span class="navbar-toggler-icon"></span>
+    </button>
+
+    <div
+      class="collapse navbar-collapse"
+      id="navbarsExampleDefault"
+      [(ngbCollapse)]="isMenuCollapsed"
+    >
+      <ul class="navbar-nav me-auto">
+        <ng-container *ngIf="occasions$ | async as occasions">
+          <li ngbDropdown class="nav-item dropdown" *ngIf="occasions.length > 0">
+            <button
+              class="nav-link"
+              id="menuMesOccasions"
+              [ngClass]="{ active: menuActif === '/occasion' }"
+              ngbDropdownToggle
             >
-          </div>
+              Mes occasions
+            </button>
+            <div
+              ngbDropdownMenu
+              class="dropdown-menu-dark"
+              aria-labelledby="menuMesOccasions"
+            >
+              <a
+                ngbDropdownItem
+                class="menuMesOccasionsItem"
+                [routerLink]="['/occasion', o.id]"
+                (click)="isMenuCollapsed = true"
+                *ngFor="let o of occasions"
+                [ngClass]="{
+                  active: menuActif === '/occasion' && idOccasionActive === o.id,
+                }"
+                >{{ o.titre }}</a
+              >
+            </div>
+          </li>
+        </ng-container>
+        <li
+          class="nav-item"
+          [ngClass]="{
+            active: menuActif === '/idee?idUtilisateur=' + utilisateur.id,
+          }"
+        >
+          <a
+            class="nav-link"
+            [routerLink]="['/idee']"
+            [queryParams]="{ idUtilisateur: utilisateur.id }"
+            (click)="isMenuCollapsed = true"
+            >Mes idées</a
+          >
         </li>
-      </ng-container>
-      <li
-        class="nav-item"
-        [ngClass]="{
-          active: menuActif === '/idee?idUtilisateur=' + utilisateur.id
-        }"
-      >
-        <a
-          class="nav-link"
-          [routerLink]="['/idee']"
-          [queryParams]="{ idUtilisateur: utilisateur.id }"
-          data-toggle="collapse"
-          data-target=".navbar-collapse.show"
-          >Mes idées</a
+        <li class="nav-item" [ngClass]="{ active: menuActif === '/profil' }">
+          <a
+            class="nav-link"
+            [routerLink]="['/profil']"
+            (click)="isMenuCollapsed = true"
+            id="menuMonProfil"
+            >Mon profil</a
+          >
+        </li>
+        <li
+          class="nav-item"
+          *ngIf="utilisateur.admin"
+          [ngClass]="{ active: menuActif === '/admin' }"
         >
-      </li>
-      <li class="nav-item" [ngClass]="{ active: menuActif === '/profil' }">
-        <a
-          class="nav-link"
-          [routerLink]="['/profil']"
-          id="menuMonProfil"
-          data-toggle="collapse"
-          data-target=".navbar-collapse.show"
-          >Mon profil</a
-        >
-      </li>
-      <li
-        class="nav-item"
-        *ngIf="utilisateur.admin"
-        [ngClass]="{ active: menuActif === '/admin' }"
-      >
-        <a
-          class="nav-link"
-          [routerLink]="['/admin']"
-          data-toggle="collapse"
-          data-target=".navbar-collapse.show"
-          >Administration</a
-        >
-      </li>
-    </ul>
+          <a
+            class="nav-link"
+            [routerLink]="['/admin']"
+            (click)="isMenuCollapsed = true"
+            >Administration</a
+          >
+        </li>
+      </ul>
 
-    <form class="form-inline">
-      <span
-        id="nomUtilisateur"
-        class="form-text me-2"
-        data-toggle="collapse"
-        data-target=".navbar-collapse.show"
-        >{{ utilisateur.nom }}</span
-      >
-      <button
-        id="btnSeDeconnecter"
-        [routerLink]="['/deconnexion']"
-        class="btn btn-secondary me-2"
-        data-toggle="collapse"
-        data-target=".navbar-collapse.show"
-      >
-        Se déconnecter
-      </button>
-    </form>
-  </div>
+      <form class="form-inline">
+        <span
+          id="nomUtilisateur"
+          class="form-text me-2"
+          >{{ utilisateur.nom }}</span
+        >
+        <button
+          id="btnSeDeconnecter"
+          [routerLink]="['/deconnexion']"
+          (click)="isMenuCollapsed = true"
+          class="btn btn-secondary me-2"
+        >
+          Se déconnecter
+        </button>
+      </form>
+    </div>
+  </ng-container>
 </nav>

--- a/front/src/app/header/header.component.ts
+++ b/front/src/app/header/header.component.ts
@@ -1,7 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { Component } from '@angular/core';
 import { Router, Event, NavigationEnd, RouterModule } from '@angular/router';
-import { NgbDropdownModule } from '@ng-bootstrap/ng-bootstrap';
+import { NgbCollapseModule, NgbDropdownModule } from '@ng-bootstrap/ng-bootstrap';
 import { filter, map } from 'rxjs/operators';
 
 import { BackendService } from '../backend.service';
@@ -9,7 +9,7 @@ import { BackendService } from '../backend.service';
 @Component({
   selector: 'app-header',
   standalone: true,
-  imports: [CommonModule, RouterModule, NgbDropdownModule],
+  imports: [CommonModule, RouterModule, NgbCollapseModule, NgbDropdownModule],
   templateUrl: './header.component.html',
   styleUrl: './header.component.scss',
 })
@@ -20,6 +20,7 @@ export class HeaderComponent {
   utilisateurConnecte$ = this.backend.utilisateurConnecte$;
   menuActif = '';
   idOccasionActive = 0;
+  isMenuCollapsed = true;
 
   constructor(
     private readonly backend: BackendService,


### PR DESCRIPTION
The hamburger menu no longer work since the last bootstrap upgrade, as we continued to use outdated attribute.

Switch to the "ngBootstrap" way of doing this with `ngbCollapseModule`, instead of using Bootstrap JS direcly, as we already did with drop-downs.