### PR TITLE
feat(config): add environment variables for docker compose port configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,12 +10,12 @@ services:
       - angular
       - slim-web
     ports:
-      - 8080:80
+      - ${FRONT_DEV_PORT:-8080}:80
 
   mailhog:
     image: mailhog/mailhog
     ports:
-      - 8025:8025
+      - ${MAILHOG_DEV_PORT:-8025}:8025
 
   mysql:
     image: mysql:5.6
@@ -100,7 +100,7 @@ services:
       - slim-fpm
     image: nginx:1.27
     ports:
-      - "8081:80"
+      - ${API_DEV_PORT:-8081}:80
     volumes:
       - ./api:/var/www/html
       - ./docker/slim-web/default.conf:/etc/nginx/conf.d/default.conf

--- a/docs/en/dev-setup.md
+++ b/docs/en/dev-setup.md
@@ -70,6 +70,12 @@ DEV_GID=YOUR_GROUP_ID
 
 **Why this matters:** Docker containers need to run with your user/group IDs to ensure file permissions are correct. Without this, files created by containers might not be accessible to you, or vice versa.
 
+### Port Configuration
+
+By default, the Docker Compose environment uses ports 8080 (frontend), 8081 (API), 8025 (MailHog), and 4200 (Angular dev server). These ports can be customized via environment variables to run multiple instances simultaneously.
+
+**For running multiple instances** (e.g., in different git worktrees), see [Environment Variables Reference - Docker Development Variables](environment-variables.md#docker-development-variables).
+
 ### API Environment Variables
 
 The API uses environment variables defined in `api/.env`. The defaults are suitable for development, but you can override them if needed.
@@ -191,6 +197,8 @@ Once the environment is running:
 - View all emails sent by the application
 - Useful for testing notifications
 
+**Note:** If you configured custom ports via environment variables, use those ports instead. See [Docker Development Variables](environment-variables.md#docker-development-variables).
+
 **Test user credentials:**
 
 Created when you run the `fixtures` command (see [Initial Setup](#initial-setup)):
@@ -250,8 +258,10 @@ graph TB
 | **slim-fpm** | PHP-FPM running the Slim Framework API       | -             |
 | **mysql**    | MySQL 5.6 database                           | -             |
 | **mailhog**  | Email testing server                         | 8025          |
-| **npm**      | Node.js tools (npm, ng, cypress, npx)        | -             |
+| **npm**      | Node.js tools (npm, ng, cypress, npx)        | 4200          |
 | **php-cli**  | PHP CLI tools (composer, doctrine, console)  | -             |
+
+**Note:** Exposed ports are configurable via environment variables. See [Docker Development Variables](environment-variables.md#docker-development-variables).
 
 ### Tool Containers
 

--- a/docs/en/environment-variables.md
+++ b/docs/en/environment-variables.md
@@ -6,6 +6,7 @@ This guide documents all environment variables used to configure Tkdo for both d
 
 - [Overview](#overview)
 - [Configuration Methods](#configuration-methods)
+- [Docker Development Variables](#docker-development-variables)
 - [Database Variables](#database-variables)
 - [Application Variables](#application-variables)
 - [Email Variables](#email-variables)
@@ -68,6 +69,138 @@ Set in Apache virtual host configuration:
 - Higher security (credentials not in files)
 - Multiple virtual hosts sharing same codebase
 - Environment-specific configuration
+
+## Docker Development Variables
+
+These variables configure port mappings for the Docker Compose development environment. They are particularly useful when running multiple instances of the application simultaneously (e.g., in different git worktrees).
+
+**Note:** These variables are only used in development with Docker Compose. They have no effect in production deployments.
+
+### FRONT_DEV_PORT
+
+**Description:** Host port mapped to the frontend web server (full application)
+
+**Type:** Integer
+
+**Required:** No
+
+**Default:** `8080`
+
+**Examples:**
+
+```bash
+FRONT_DEV_PORT=8080    # Default port
+FRONT_DEV_PORT=9080    # Alternative port for second instance
+FRONT_DEV_PORT=3000    # Custom port
+```
+
+**Usage:**
+
+- Set in `.env` file at project root (not `api/.env`)
+- Access the application at `http://localhost:${FRONT_DEV_PORT}`
+- Change when running multiple instances to avoid port conflicts
+- Each worktree should use a different port
+
+### MAILHOG_DEV_PORT
+
+**Description:** Host port mapped to the MailHog email testing UI
+
+**Type:** Integer
+
+**Required:** No
+
+**Default:** `8025`
+
+**Examples:**
+
+```bash
+MAILHOG_DEV_PORT=8025    # Default port
+MAILHOG_DEV_PORT=9025    # Alternative port for second instance
+MAILHOG_DEV_PORT=8125    # Custom port
+```
+
+**Usage:**
+
+- Set in `.env` file at project root (not `api/.env`)
+- Access MailHog UI at `http://localhost:${MAILHOG_DEV_PORT}`
+- Change when running multiple instances to avoid port conflicts
+- Used only in development to view test emails
+
+### API_DEV_PORT
+
+**Description:** Host port mapped to the backend API server (direct API access)
+
+**Type:** Integer
+
+**Required:** No
+
+**Default:** `8081`
+
+**Examples:**
+
+```bash
+API_DEV_PORT=8081    # Default port
+API_DEV_PORT=9081    # Alternative port for second instance
+API_DEV_PORT=3001    # Custom port
+```
+
+**Usage:**
+
+- Set in `.env` file at project root (not `api/.env`)
+- Access API directly at `http://localhost:${API_DEV_PORT}`
+- Change when running multiple instances to avoid port conflicts
+- Useful for API testing and debugging
+
+### NPM_DEV_PORT
+
+**Description:** Host port mapped to the Angular development server when running `./npm` script
+
+**Type:** Integer
+
+**Required:** No
+
+**Default:** `4200`
+
+**Examples:**
+
+```bash
+NPM_DEV_PORT=4200    # Default Angular dev server port
+NPM_DEV_PORT=4201    # Alternative port for second instance
+NPM_DEV_PORT=5000    # Custom port
+```
+
+**Usage:**
+
+- Set in `.env` file at project root (not `api/.env`)
+- Used when running `./npm` script for live development server
+- Access Angular dev server at `http://localhost:${NPM_DEV_PORT}`
+- Change when running multiple instances to avoid port conflicts
+
+### Running Multiple Instances
+
+When working with multiple git worktrees or wanting to run multiple instances simultaneously, create a `.env` file at the project root with unique ports:
+
+**First instance** (default ports - no .env needed):
+```bash
+# Uses defaults: 8080, 8081, 8025, 4200
+docker compose up -d front
+```
+
+**Second instance** (custom ports in `.env`):
+```bash
+# .env at project root
+FRONT_DEV_PORT=9080
+API_DEV_PORT=9081
+MAILHOG_DEV_PORT=9025
+NPM_DEV_PORT=4201
+```
+
+Then start normally:
+```bash
+docker compose up -d front
+```
+
+**Note:** The `.env` file should be at the project root, not in the `api/` directory. Docker Compose reads environment variables from the project root `.env` file.
 
 ## Database Variables
 
@@ -567,6 +700,10 @@ TKDO_DEV_MODE=0
 
 | Variable             | Required | Default                 | Type      | Category    |
 | -------------------- | -------- | ----------------------- | --------- | ----------- |
+| `FRONT_DEV_PORT`     | No       | `8080`                  | Integer   | Docker Dev  |
+| `MAILHOG_DEV_PORT`   | No       | `8025`                  | Integer   | Docker Dev  |
+| `API_DEV_PORT`       | No       | `8081`                  | Integer   | Docker Dev  |
+| `NPM_DEV_PORT`       | No       | `4200`                  | Integer   | Docker Dev  |
 | `MYSQL_HOST`         | No       | `mysql` or `127.0.0.1`  | String    | Database    |
 | `MYSQL_PORT`         | No       | `3306`                  | Integer   | Database    |
 | `MYSQL_DATABASE`     | No       | `tkdo`                  | String    | Database    |

--- a/docs/en/frontend-dev.md
+++ b/docs/en/frontend-dev.md
@@ -487,14 +487,15 @@ The Angular development server provides hot reload and API mocking for rapid fro
 "serve": {
   "options": {
     "host": "0.0.0.0",
-    "proxyConfig": "src/proxy.conf.json"
+    "proxyConfig": "src/proxy.conf.js"
   }
 }
 ```
 
-**Proxy Configuration** (`src/proxy.conf.json`):
+**Proxy Configuration** (`src/proxy.conf.js`):
 - Used when dev server needs to proxy to real API
 - Currently, dev server uses interceptor mocking instead
+- Uses environment variable `FRONT_DEV_PORT` (default: 8080) for target port
 
 ## Dev Backend Interceptor
 

--- a/front/angular.json
+++ b/front/angular.json
@@ -64,7 +64,7 @@
           "builder": "@angular-devkit/build-angular:dev-server",
           "options": {
             "host": "0.0.0.0",
-            "proxyConfig": "src/proxy.conf.json"
+            "proxyConfig": "src/proxy.conf.js"
           },
           "configurations": {
             "production": {

--- a/front/cypress.config.ts
+++ b/front/cypress.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'cypress';
 
 export default defineConfig({
   e2e: {
-    baseUrl: 'http://localhost:4200',
+    baseUrl: `http://localhost:${process.env.NPM_DEV_PORT || 4200}`,
   },
 
   component: {

--- a/front/src/app/header/header.component.cy.ts
+++ b/front/src/app/header/header.component.cy.ts
@@ -33,7 +33,11 @@ function createMockBackend(
 describe('HeaderComponent', () => {
   it('should mount', () => {
     cy.mount(HeaderComponent, {
-      providers: [provideRouter([]), provideHttpClient(), provideHttpClientTesting()],
+      providers: [
+        provideRouter([]),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+      ],
     });
   });
 

--- a/front/src/proxy.conf.js
+++ b/front/src/proxy.conf.js
@@ -1,0 +1,6 @@
+module.exports = {
+  "/api": {
+    target: `http://localhost:${process.env.FRONT_DEV_PORT || 8080}`,
+    secure: false,
+  },
+};

--- a/front/src/proxy.conf.json
+++ b/front/src/proxy.conf.json
@@ -1,6 +1,0 @@
-{
-  "/api": {
-    "target": "http://localhost:8080",
-    "secure": false
-  }
-}


### PR DESCRIPTION
## Summary

This PR adds environment variables to configure Docker Compose exposed ports, enabling multiple instances of the application to run simultaneously without port conflicts (e.g., in different git worktrees).

## Changes

### Docker Compose Port Configuration
- **docker-compose.yml**: Updated port mappings to use environment variables with sensible defaults
  - `FRONT_DEV_PORT` (default: 8080) - Frontend web server
  - `API_DEV_PORT` (default: 8081) - Backend API server  
  - `MAILHOG_DEV_PORT` (default: 8025) - MailHog email testing UI
  - Documented existing `NPM_DEV_PORT` (default: 4200) - Angular dev server

### Frontend Configuration Updates
- **cypress.config.ts**: Use `NPM_DEV_PORT` environment variable for integration test base URL
- **proxy.conf.json → proxy.conf.js**: Converted to JavaScript to support `FRONT_DEV_PORT` environment variable
- **angular.json**: Updated proxy configuration reference from `.json` to `.js`

### Documentation
- **docs/en/environment-variables.md**: Added comprehensive "Docker Development Variables" section with:
  - Detailed documentation for each variable
  - Examples for running multiple instances
  - Usage guidelines
- **docs/en/dev-setup.md**: Added port configuration section with cross-links to detailed documentation
- **docs/en/frontend-dev.md**: Updated proxy configuration reference

All documentation follows the single source of truth principle with detailed information in `environment-variables.md` and cross-references from other docs.

## Testing

- [x] All frontend tests pass (unit, component, integration)
- [x] All backend tests pass (unit and integration)
- [x] Docker Compose configuration validates successfully
- [x] Default behavior unchanged (all defaults match previous hardcoded values)
- [x] Documentation follows single source of truth principle
- [x] All cross-references are valid

## Use Case

This change addresses the need to run multiple development instances simultaneously, which is common when using git worktrees for parallel development. Example `.env` configuration for a second instance:

```bash
# .env at project root
FRONT_DEV_PORT=9080
API_DEV_PORT=9081
MAILHOG_DEV_PORT=9025
NPM_DEV_PORT=4201
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)