### PR TITLE
chore(front): ensure ./npm uses NPM_DEV_PORT when set

### DIFF
--- a/npm
+++ b/npm
@@ -1,2 +1,3 @@
 #!/usr/bin/env bash
+[ -f .env ] && source .env
 docker compose run --publish=${NPM_DEV_PORT:-4200}:4200 --rm npm "$@"


### PR DESCRIPTION
Loading the `.env` file was mission from the `./npm` helper, so port 4200 was still used by all worktrees, leading to conflicts.