### PR TITLE
fix(ci): stop using restore key with firefox cache

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -148,9 +148,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /opt/hostedtoolcache/firefox
-          key: ${{ runner.os }}-firefox-latest-v4-${{ steps.week.outputs.week }}
-          restore-keys: |
-            ${{ runner.os }}-firefox-latest-v4-
+          key: ${{ runner.os }}-firefox-latest-v5-${{ steps.week.outputs.week }}
 
       # Install Firefox for firefox browser tests
       - name: Install Firefox from cache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,9 +96,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /opt/hostedtoolcache/firefox
-          key: ${{ runner.os }}-firefox-latest-v4-${{ steps.week.outputs.week }}
-          restore-keys: |
-            ${{ runner.os }}-firefox-latest-v4-
+          key: ${{ runner.os }}-firefox-latest-v5-${{ steps.week.outputs.week }}
 
       # Install Firefox for firefox browser tests
       - name: Install Firefox from cache


### PR DESCRIPTION
As:
- it breaks the current cache cleaning
- the latest firefox will be downloaded anyway
- and old versions would have to be cleansed from the cache